### PR TITLE
Makefile: force shell to bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@
 
 BUILD_SCRIPT := meta-baylibre/build.sh
 
+SHELL := /bin/bash
 MY_BUILDDIR ?= build
 OUTDIR = $(MY_BUILDDIR)
 IMAGENAME ?= baylibre-acme-image


### PR DESCRIPTION
The Makefile is using 'source' which doesn't exist in /bin/sh, so
needs to force the shell to bash which has 'source' available,
otherwise, the build ends with this error:

...
NOTE: Preparing RunQueue
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 2338 tasks of which 2338 didn't need to be rerun and all succeeded.
mkdir -p build
source poky/oe-init-build-env && bitbake -e > ../build/baylibre-acme-image.env
/bin/sh: 1: source: not found
Makefile:51: recipe for target 'sdcard' failed
make: *** [sdcard] Error 127

Signed-off-by: Kevin Hilman <khilman@baylibre.com>