### PR TITLE
iio: init: fix shifted shunt resistor values

### DIFF
--- a/meta-baylibre-acme/recipes-core/acme-iio-init/acme-iio-init
+++ b/meta-baylibre-acme/recipes-core/acme-iio-init/acme-iio-init
@@ -7,7 +7,7 @@ do
   if [ -f /sys/bus/i2c/devices/1-004$probe/iio:device*/in_shunt_resistor ]
   then
 	iiodevice=`ls /sys/bus/i2c/devices/1-004$probe/iio:device*/in_shunt_resistor`
-	rshunt=`dut-dump-probe -b 1 -r $probe`
+	rshunt=`dut-dump-probe -b 1 -r $((probe+1))`
 	echo $rshunt > $iiodevice
   fi
 done


### PR DESCRIPTION
Shunt resistor values are incorrect, due to different start index.
The script 'probe' variable starts with 0, but 'dut-dump-probe'
index starts with 1. This causes probe in first slot to always use
the default value, and the second probe to use the value of the
first one (and so on).
This patch complements commit 659f0645f7a931344815967406da429182b22c7f
('Since the iio:device number is not equal to the probe number...').

To validate this patch, probes flashed with special shunt resistor
respective values of 1,2,3,4,5,6,7,8 were used and inserted in
corresponding slots 1,2,3,4,5,6,7,8 (as labelled on the cape).

Here are the reported shunt resistor values without this patch:
root@baylibre-acme:~# for probe in 0 1 2 3 4 5 6 7
> do
> cat /sys/bus/i2c/devices/1-004$probe/iio:device*/in_shunt_resistor
> done
10000
1
2
3
4
5
6
7

And here are the reported shunt resistor values with this patch:
root@baylibre-acme:~# for probe in 0 1 2 3 4 5 6 7
> do
> cat /sys/bus/i2c/devices/1-004$probe/iio:device*/in_shunt_resistor
> done
1
2
3
4
5
6
7
8

Signed-off-by: Patrick Titiano <ptitiano@baylibre.com>

Fixes #14 